### PR TITLE
Update CI 02 2025 

### DIFF
--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -36,7 +36,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.64.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Linux an
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-compiler:
-    description: "gcc9 apple-clang"
+    description: "gcc apple-clang"
     required: true
   conan-cc:
     description: "gcc clang"
@@ -12,7 +12,7 @@ inputs:
     description: "g++ clang++"
     required: true
   conan-compiler-version:
-    description: "A number [gcc: 5 6 7 8 9 ] [clang: 39 40 50 60 7 8 9] [10.0]"
+    description: "A number [gcc: 5 6 7 8 9 10 11 12 13 14] [clang: 39 40 50 60 7 8 9 10 11 12 13 14 15 16 17 18 19 20] [10.0]"
     required: true
   conan-libcxx-version:
     description: "Linux: libstdc++ or Macos: libc++ "

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -48,8 +48,8 @@ runs:
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
           if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
-            brew update && brew install -f --overwrite python@3.13 && brew install libomp && brew link libomp --force
-            brew link --overwrite python@3.13
+            brew update && brew install -f --overwrite python@3.11 && brew install libomp && brew link libomp --force
+            brew link --overwrite python@3.11
             brew link --force libomp
         else
             brew install libomp

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -63,9 +63,15 @@ runs:
     - name: Build with conan
       run: |
 
-        echo $OPENMP_ROOT
+        echo ${{ env.OpenMP_ROOT }}
 
         export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+        echo $OPENMP_ROOT
+
+        export OpenMP_ROOT=Test
+        echo $OPENMP_ROOT
+
+        export OpenMP_ROOT=${{ env.OpenMP_ROOT }}
         echo $OPENMP_ROOT
 
         export CONAN_USER_HOME=`pwd`/_conan

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -59,6 +59,10 @@ runs:
           sudo apt-get install -y libopenblas-dev
         fi
 
+        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then
+          brew install libomp 
+        fi
+
       shell: bash
 
     - name: Build with conan
@@ -70,6 +74,10 @@ runs:
         conan user -r $CONAN_LKEB_ARTIFACTORY -p ${{ inputs.conan-password }} ${{ inputs.conan-user }}
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
 
+        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then
+          export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+        fi
+        
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build
         conan profile update settings.os_build=${{ inputs.conan-build-os }} action_build

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -46,10 +46,6 @@ runs:
           sudo apt-get install -y ninja-build
         fi
 
-        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
-          brew install libomp
-        fi
-
         export CONAN_CMAKE_PROGRAM=`which cmake`
         echo CMake version:
         cmake --version
@@ -66,19 +62,6 @@ runs:
     - name: Build with conan
       run: |
       
-        echo Test START
-        echo "$(brew --prefix)/opt/libomp"
-        export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-        echo $OpenMP_ROOT
-        echo Test END
-
-        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
-          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
-            export LDFLAGS="-L$OpenMP_ROOT/lib"
-            export CPPFLAGS="-I$OpenMP_ROOT/include"
-         fi
-        fi
-
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -47,13 +47,7 @@ runs:
         fi
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
-          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
-            brew update && brew install -f --overwrite python@3.13 && brew install libomp && brew link libomp --force
-            brew link --overwrite python@3.13
-            brew link --force libomp
-        else
-            brew install libomp
-          fi
+          brew install libomp
         fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`
@@ -77,6 +71,13 @@ runs:
         export OpenMP_ROOT=$(brew --prefix)/opt/libomp
         echo $OpenMP_ROOT
         echo Test END
+
+        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
+          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
+            export LDFLAGS="-L$OpenMP_ROOT/lib"
+            export CPPFLAGS="-I$OpenMP_ROOT/include"
+         fi
+        fi
 
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -48,12 +48,11 @@ runs:
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
           export HOMEBREW_NO_AUTO_UPDATE=1
-
-          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then 
-            brew install llvm 
-          fi
-
           brew install libomp 
+          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then 
+            brew link --overwrite python@3.11
+            brew link --force libomp
+          fi
         fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -38,9 +38,7 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install wheel
         pip install conan~=1.66.0
-        pip install "markupsafe<2.1"
 
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then 
           sudo apt-get update
@@ -66,7 +64,6 @@ runs:
 
     - name: Build with conan
       run: |
-      
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -47,10 +47,12 @@ runs:
         fi
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
-          export HOMEBREW_NO_AUTO_UPDATE=1
-          brew install libomp 
-          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then 
+          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
+            brew update && brew install -f --overwrite python@3.13 && brew install libomp && brew link libomp --force
+            brew link --overwrite python@3.13
             brew link --force libomp
+        else
+            brew install libomp
           fi
         fi
 

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -59,10 +59,6 @@ runs:
           sudo apt-get install -y libopenblas-dev
         fi
 
-        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then
-          brew install libomp 
-        fi
-
       shell: bash
 
     - name: Build with conan
@@ -73,10 +69,6 @@ runs:
         echo Add upload user
         conan user -r $CONAN_LKEB_ARTIFACTORY -p ${{ inputs.conan-password }} ${{ inputs.conan-user }}
         export CONAN_PACKAGE_NAME=`conan inspect --raw name conanfile.py`
-
-        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then
-          export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-        fi
         
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -23,6 +23,9 @@ inputs:
   conan-build-os:
     description: "Linux or Macos"
     required: true
+  build-arch:
+    description: "either x86_64 or armv8 (for macos)"
+    required: true
   conan-user:
     description: "pass secrets.LKEB_ARTIFACTORY_USER"
     required: true
@@ -72,8 +75,8 @@ runs:
         conan profile new action_build
         conan profile update settings.os=${{ inputs.conan-build-os }} action_build
         conan profile update settings.os_build=${{ inputs.conan-build-os }} action_build
-        conan profile update settings.arch=x86_64 action_build
-        conan profile update settings.arch_build=x86_64 action_build
+        conan profile update settings.arch=${{ inputs.build-arch }} action_build
+        conan profile update settings.arch_build=${{ inputs.build-arch }} action_build
         conan profile update settings.compiler=${{ inputs.conan-compiler }} action_build
         conan profile update settings.compiler.version=${{ inputs.conan-compiler-version }} action_build
         conan profile update settings.compiler.libcxx=${{ inputs.conan-libcxx-version}} action_build

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -41,7 +41,6 @@ runs:
         pip install wheel
         pip install conan~=1.66.0
         pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
 
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then 
           sudo apt-get update
@@ -49,9 +48,12 @@ runs:
           sudo apt-get install -y ninja-build
         fi
 
-        export CONAN_CMAKE_PROGRAM=`which cmake`
-        echo CMake version:
+        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
+          export HOMEBREW_NO_AUTO_UPDATE=1
+        fi
+
         cmake --version
+        export CONAN_CMAKE_PROGRAM=`which cmake`
         mkdir `pwd`/_conan
         export CONAN_USER_HOME=`pwd`/_conan
         conan user

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -47,6 +47,12 @@ runs:
         fi
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
+          export HOMEBREW_NO_AUTO_UPDATE=1
+
+          if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then 
+            brew install llvm 
+          fi
+
           brew install libomp 
         fi
 
@@ -55,7 +61,6 @@ runs:
         cmake --version
         mkdir `pwd`/_conan
         export CONAN_USER_HOME=`pwd`/_conan
-        export HOMEBREW_NO_AUTO_UPDATE=1
         conan user
 
         echo Extend conan cacert.pem
@@ -67,10 +72,11 @@ runs:
     - name: Build with conan
       run: |
       
-        echo Test 
+        echo Test START
         echo "$(brew --prefix)/opt/libomp"
         export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-        echo $OPENMP_ROOT
+        echo $OpenMP_ROOT
+        echo Test END
 
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -39,7 +39,16 @@ runs:
         pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
-        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi
+
+        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then 
+          sudo apt-get update
+          sudo apt-get install -y libopenblas-dev
+          sudo apt-get install -y ninja-build
+        fi
+
+        if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
+          brew install libomp 
+        fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`
         echo CMake version:
@@ -52,26 +61,15 @@ runs:
         echo Extend conan cacert.pem
         conanhome=`conan config home`
         cat cert.pem >> $conanhome/cacert.pem
-        
-        if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then
-          sudo apt-get update
-          sudo apt-get install -y libopenblas-dev
-        fi
 
       shell: bash
 
     - name: Build with conan
       run: |
-
-        echo ${{ env.OpenMP_ROOT }}
-
+      
+        echo Test 
+        echo "$(brew --prefix)/opt/libomp"
         export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-        echo $OPENMP_ROOT
-
-        export OpenMP_ROOT=Test
-        echo $OPENMP_ROOT
-
-        export OpenMP_ROOT=${{ env.OpenMP_ROOT }}
         echo $OPENMP_ROOT
 
         export CONAN_USER_HOME=`pwd`/_conan

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -50,7 +50,6 @@ runs:
           export HOMEBREW_NO_AUTO_UPDATE=1
           brew install libomp 
           if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then 
-            brew link --overwrite python@3.11
             brew link --force libomp
           fi
         fi

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -48,8 +48,8 @@ runs:
 
         if [[ ${{ inputs.conan-build-os }} == "Macos" ]]; then 
           if [[ ${{ inputs.conan-compiler-version }} > 14 ]]; then
-            brew update && brew install -f --overwrite python@3.11 && brew install libomp && brew link libomp --force
-            brew link --overwrite python@3.11
+            brew update && brew install -f --overwrite python@3.13 && brew install libomp && brew link libomp --force
+            brew link --overwrite python@3.13
             brew link --force libomp
         else
             brew install libomp

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -64,6 +64,10 @@ runs:
       run: |
 
         echo $OPENMP_ROOT
+
+        export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+        echo $OPENMP_ROOT
+
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD

--- a/.github/conan_linuxmac_build/action.yml
+++ b/.github/conan_linuxmac_build/action.yml
@@ -39,7 +39,6 @@ runs:
         pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
-        pip install h5py
         if [[ ${{ inputs.conan-build-os }} == "Linux" ]]; then sudo apt-get install -y ninja-build; fi
 
         export CONAN_CMAKE_PROGRAM=`which cmake`
@@ -63,6 +62,8 @@ runs:
 
     - name: Build with conan
       run: |
+
+        echo $OPENMP_ROOT
         export CONAN_USER_HOME=`pwd`/_conan
         echo Add LKEB artifactory as remote
         conan remote add $CONAN_LKEB_ARTIFACTORY $CONAN_UPLOAD

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -3,7 +3,7 @@ description: "Encapsulate cmake composite run steps that are common for Windows,
 # reference https://docs.github.com/en/free-pro-team@latest/actions/creating-actions/creating-a-composite-run-steps-action
 inputs:
   conan-visual-version:
-    description: "MSVC version: 15, 16 represent msvc-2017 or msvc-2019"
+    description: "MSVC version: 16, 17 represent msvc-2019 and msvc-2022"
     required: true
   conan-visual-runtime:
     description: "MD or MDd"

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -54,7 +54,6 @@ runs:
       run: |
         for /f "delims=" %%i in ('where cmake') do set CONAN_CMAKE_PROGRAM="%%i"
         set CONAN_USER_HOME=%cd%\_conan
-        set VS160COMNTOOLS="C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools"
 
         echo Add LKEB artifactory as remote at URL: %CONAN_UPLOAD%
         conan remote add %CONAN_LKEB_ARTIFACTORY% %CONAN_UPLOAD%

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install conan & build configuration
       run: |
         pip install wheel
-        pip install conan~=1.54.0
+        pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
         pip install h5py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -27,7 +27,6 @@ runs:
         pip install conan~=1.66.0
         pip install "markupsafe<2.1"
         pip install -Iv cmake>=3.17
-        pip install h5py
 
         REM Fish the package name from the conanfile.py
         conan inspect -j __props__.json -a name conanfile.py

--- a/.github/conan_windows_build/action.yml
+++ b/.github/conan_windows_build/action.yml
@@ -23,10 +23,7 @@ runs:
   steps:
     - name: Install conan & build configuration
       run: |
-        pip install wheel
         pip install conan~=1.66.0
-        pip install "markupsafe<2.1"
-        pip install -Iv cmake>=3.17
 
         REM Fish the package name from the conanfile.py
         conan inspect -j __props__.json -a name conanfile.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.11"
 
       - name: Setup gcc for Linux
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++11
+            build-arch: x86_64
 
           - name: Linux_gcc13
             os: ubuntu-24.04
@@ -67,6 +68,7 @@ jobs:
             build-os: Macos
             build-xcode-version: 14.3
             build-libcxx: libc++
+            build-arch: x86_64
 
           - name: Macos_xcode15
             os: macos-14
@@ -76,6 +78,7 @@ jobs:
             build-os: Macos
             build-xcode-version: 15.4
             build-libcxx: libc++
+            build-arch: armv8
   
           - name: Macos_xcode16
             os: macos-15
@@ -85,6 +88,7 @@ jobs:
             build-os: Macos
             build-xcode-version: 16.2
             build-libcxx: libc++
+            build-arch: armv8
 
     steps:
       - name: Checkout the source
@@ -130,6 +134,7 @@ jobs:
           conan-libcxx-version: ${{matrix.build-libcxx}}
           conan-build-type: ${{matrix.build-config}}
           conan-build-os: ${{matrix.build-os}}
+          build-arch: ${{matrix.build-arch}}
           conan-user: ${{secrets.LKEB_UPLOAD_USER}}
           conan-password: ${{secrets.LKEB_UPLOAD_USER_PASSWORD}}
           conan-pem: ${{secrets.LKEB_UPLOAD_CERT_CHAIN}}
@@ -145,6 +150,7 @@ jobs:
           conan-libcxx-version: ${{matrix.build-libcxx}}
           conan-build-type: ${{matrix.build-config}}
           conan-build-os: ${{matrix.build-os}}
+          build-arch: ${{matrix.build-arch}}
           conan-user: ${{secrets.LKEB_UPLOAD_USER}}
           conan-password: ${{secrets.LKEB_UPLOAD_USER_PASSWORD}}
           conan-pem: ${{secrets.LKEB_UPLOAD_CERT_CHAIN}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,12 +92,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup OpenMP (Mac only)
-        if: startsWith(runner.os, 'macOS')
-        run: |
-          brew install libomp
-          echo "OpenMP_ROOT=$(brew --prefix)/opt/libomp" >> $GITHUB_ENV
-
       - name: Select Xcode (Mac only)
         if: startsWith(runner.os, 'macOS')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
             build-config: Release
             build-os: Linux
             build-libcxx: libstdc++11
+            build-arch: x86_64
 
           - name: Macos_xcode14.3
             os: macos-13

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Select Xcode for Mac only
+      - name: Setup OpenMP (Mac only)
+        if: startsWith(runner.os, 'macOS')
+        run: |
+          brew install libomp
+          echo "OpenMP_ROOT=$(brew --prefix)/opt/libomp" >> $GITHUB_ENV
+
+      - name: Select Xcode (Mac only)
         if: startsWith(runner.os, 'macOS')
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
@@ -139,6 +145,8 @@ jobs:
       - name: Mac build
         if: startsWith(matrix.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
+        env:
+          OpenMP_ROOT: ${{ env.OpenMP_ROOT }}
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-compiler-version: ${{matrix.build-cversion}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,6 @@ jobs:
         if: startsWith(runner.os, 'macOS')
         run: |
           sudo xcode-select -switch /Applications/Xcode_${{matrix.build-xcode-version}}.app
-          brew install libomp
 
       - name: Setup python version
         uses: actions/setup-python@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,12 @@ jobs:
         with:
           submodules: recursive
 
+      - name: Install system dependencies (MacOS)
+        if: startsWith(runner.os, 'macOS')
+        run: |
+          brew install libomp
+          export OpenMP_ROOT=$(brew --prefix)/opt/libomp
+
       - name: Select Xcode for Mac only
         if: startsWith(runner.os, 'macOS')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup python version
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
 
       - name: Setup gcc for Linux
         if: startsWith(runner.os, 'Linux')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,8 +145,6 @@ jobs:
       - name: Mac build
         if: startsWith(matrix.os, 'macOS')
         uses: ./.github/conan_linuxmac_build
-        env:
-          OpenMP_ROOT: ${{ env.OpenMP_ROOT }}
         with:
           conan-compiler: ${{matrix.build-compiler}}
           conan-compiler-version: ${{matrix.build-cversion}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,13 +107,6 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Setup gcc for Linux
-        if: startsWith(runner.os, 'Linux')
-        uses: egor-tensin/setup-gcc@v1
-        with:
-          version: ${{matrix.build-cversion}}
-          platform: x64
-
       - name: Windows build
         if: startsWith(matrix.os, 'windows')
         uses: ./.github/conan_windows_build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,12 +92,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install system dependencies (MacOS)
-        if: startsWith(runner.os, 'macOS')
-        run: |
-          brew install libomp
-          export OpenMP_ROOT=$(brew --prefix)/opt/libomp
-
       - name: Select Xcode for Mac only
         if: startsWith(runner.os, 'macOS')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,12 @@ jobs:
             build-runtime: MD
             build-config: Release
 
-#          - name: Linux_gcc10
-#            os: ubuntu-20.04
-#            build-compiler: gcc
-#            build-cversion: 10
-#            build-config: Release
-#            build-os: Linux
-#            build-libcxx: libstdc++
+          - name: Windows-msvc2022
+            os: windows-2022
+            compiler: msvc-2022
+            build-cversion: 17
+            build-runtime: MD
+            build-config: Release
 
           - name: Linux_gcc11
             os: ubuntu-22.04
@@ -60,15 +59,6 @@ jobs:
             build-os: Linux
             build-libcxx: libstdc++11
 
-          - name: Macos_xcode13.4
-            os: macos-12
-            build-compiler: apple-clang
-            build-cversion: 13
-            build-config: Release
-            build-os: Macos
-            build-xcode-version: 13.4
-            build-libcxx: libc++
-
           - name: Macos_xcode14.3
             os: macos-13
             build-compiler: apple-clang
@@ -78,19 +68,27 @@ jobs:
             build-xcode-version: 14.3
             build-libcxx: libc++
 
-          # - name: Macos_xcode15.3
-          #  os: macos-14-large
-          #  build-compiler: apple-clang
-          #  build-cversion: 15
-          #  build-config: Release
-          #  build-os: Macos
-          #  build-xcode-version: 15.3
-          #  build-libcxx: libc++
-
+          - name: Macos_xcode15
+            os: macos-14
+            build-compiler: apple-clang
+            build-cversion: 15
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 15.4
+            build-libcxx: libc++
+  
+          - name: Macos_xcode16
+            os: macos-15
+            build-compiler: apple-clang
+            build-cversion: 16
+            build-config: Release
+            build-os: Macos
+            build-xcode-version: 16.2
+            build-libcxx: libc++
 
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,11 +88,11 @@ class FaissConan(ConanFile):
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
-        #if os_info.is_macos:
-            # proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            # prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            # print(f"prefix_path: {prefix_path}")
-            # tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            print(f"prefix_path: {prefix_path}")
+            tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,16 +95,17 @@ class FaissConan(ConanFile):
             proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
             cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
             #cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+            cmake_version_major = int(cmake_version.split('.')[0])
+            cmake_version_minor = int(cmake_version.split('.')[1])
 
             print(f"cmake version: {cmake_version}")
-            print(f"version_tuple[0]: {version_tuple[0]}")
-            print(f"version_tuple[1]: {version_tuple[1]}")
+            print(f"cmake_version_major: {cmake_version_major}")
+            print(f"cmake_version_minor: {cmake_version_minor}")
 
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-            if version_tuple[0] == 3 and version_tuple[1] > 26:
+            if cmake_version_major == 3 and cmake_version_minor > 26:
                 print("Workaround...")
                 tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
                 tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 

--- a/conanfile.py
+++ b/conanfile.py
@@ -76,6 +76,12 @@ class FaissConan(ConanFile):
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            print(f"prefix_path: {prefix_path}")
+            tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
+
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
         return tc

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,7 +42,9 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        pass
+        if os_info.is_macos:
+            installer = SystemPackageTool()
+            installer.install("libomp")
 
     def generate(self):
         print("In generate")
@@ -85,6 +87,33 @@ class FaissConan(ConanFile):
 
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
+
+        # cmake might have issues with finding openmp
+        # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
+        # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
+        if os_info.is_macos:
+            proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
+            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+            cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
+            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+
+            print(f"cmake version: {cmake_version}")
+            print(f"version_tuple: {version_tuple}")
+
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+
+            if version_tuple[0] == 3 and version_tuple[1] > 26:
+                print("Workaround...")
+                tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
+                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+                tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
+                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
+                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
+                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
+            else:
+                tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -91,13 +91,13 @@ class FaissConan(ConanFile):
         # cmake might have issues with finding openmp
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        # if os_info.is_macos:
-        #     proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
-        #     cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+        if os_info.is_macos:
+            proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
+            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
         #     cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
         #     version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
 
-        #     print(f"cmake version: {cmake_version}")
+            print(f"cmake version: {cmake_version}")
         #     print(f"version_tuple: {version_tuple}")
 
         #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
@@ -148,6 +148,8 @@ class FaissConan(ConanFile):
         print(f"OpenMP_ROOT {omp_prefix_path}")
 
         os.environ["OpenMP_ROOT"] = omp_prefix_path
+        os.environ["LDFLAGS"] = f"{omp_prefix_path}/lib"
+        os.environ["CPPFLAGS"] = f"{omp_prefix_path}/include"
 
         cmake_debug = self._configure_cmake()
         cmake_debug.build(build_type="Debug")

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,9 +42,7 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        if os_info.is_macos:
-            installer = SystemPackageTool()
-            installer.install("libomp")
+        pass
 
     def generate(self):
         print("In generate")
@@ -87,12 +85,6 @@ class FaissConan(ConanFile):
 
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
-
-        if os_info.is_macos:
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            print(f"omp_prefix_path: {omp_prefix_path}")
-            tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,4 +1,4 @@
-from conans import ConanFile, tools
+from conans import ConanFile
 from conan.tools.cmake import CMakeDeps, CMake, CMakeToolchain
 from conans.tools import os_info, SystemPackageTool, get_env
 import os
@@ -20,6 +20,8 @@ class FaissConan(ConanFile):
     topics = ("clustering", "similarity")
     settings = "os", "compiler", "build_type", "arch"
     options = {"shared": [True, False], "testing": [True, False]}
+
+    short_paths = True
     default_options = {"shared": True, "testing": False}
     generators = "CMakeDeps"
     exports = "cmake/*"
@@ -42,13 +44,14 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        if os_info.is_macos:
-            installer = SystemPackageTool()
-            installer.install("libomp")
-            # Make the brew OpenMP findable with a symlink
-            proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
-            subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
-            
+        pass
+        # if os_info.is_macos:
+        #     installer = SystemPackageTool()
+        #     installer.install("libomp")
+        #     # Make the brew OpenMP findable with a symlink
+        #     proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
+        #     subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
+
     def generate(self):
         print("In generate")
         """Generate the CMake configuration using
@@ -71,6 +74,7 @@ class FaissConan(ConanFile):
             generator = "Ninja Multi-Config"
 
         tc = CMakeToolchain(self, generator=generator)
+
         tc.variables["FAISS_ENABLE_PYTHON "] = "OFF"
         tc.variables["FAISS_ENABLE_GPU "] = "OFF"
         tc.variables["BUILD_TESTING"] = "ON" if self.options.testing else "OFF"
@@ -94,10 +98,10 @@ class FaissConan(ConanFile):
         # cmake might have issues with finding openmp
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        if os_info.is_macos:
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
-            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            tc.variables["OpenMP_ROOT"] = omp_prefix_path
+        # if os_info.is_macos:
+        #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
+        #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+        #     tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,13 +95,10 @@ class FaissConan(ConanFile):
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
-        # cmake might have issues with finding openmp
-        # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
-        # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        # if os_info.is_macos:
-        #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
-        #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-        #     tc.variables["OpenMP_ROOT"] = omp_prefix_path
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
+            tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
+            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp "
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,13 +92,13 @@ class FaissConan(ConanFile):
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
         if os_info.is_macos:
-            proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
+            proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
             cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
         #     cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-        #     version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
 
             print(f"cmake version: {cmake_version}")
-        #     print(f"version_tuple: {version_tuple}")
+            print(f"version_tuple: {version_tuple}")
 
         #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
         #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
@@ -147,9 +147,15 @@ class FaissConan(ConanFile):
 
         print(f"OpenMP_ROOT {omp_prefix_path}")
 
+        value = os.getenv("LDFLAGS")
+        print(value if value is not None else "LDFLAGS variable not set")
+
+        value = os.getenv("CPPFLAGS")
+        print(value if value is not None else "CPPFLAGS variable not set")
+
         os.environ["OpenMP_ROOT"] = omp_prefix_path
-        os.environ["LDFLAGS"] = f"{omp_prefix_path}/lib"
-        os.environ["CPPFLAGS"] = f"{omp_prefix_path}/include"
+        #os.environ["LDFLAGS"] = f"{omp_prefix_path}/lib"
+        #os.environ["CPPFLAGS"] = f"{omp_prefix_path}/include"
 
         cmake_debug = self._configure_cmake()
         cmake_debug.build(build_type="Debug")

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,7 +45,10 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             installer = SystemPackageTool()
             installer.install("libomp")
-
+            # Make the brew OpenMP findable with a symlink
+            proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
+            subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
+            
     def generate(self):
         print("In generate")
         """Generate the CMake configuration using
@@ -94,17 +97,7 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-
-            tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
-            tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-            tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
-            tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
-            tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-            tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
-            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
-
-            #tc.variables["OpenMP_ROOT"] = omp_prefix_path
-            #os.environ["OpenMP_ROOT"] = omp_prefix_path
+            tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
@@ -133,21 +126,6 @@ class FaissConan(ConanFile):
 # '''.format(line_to_replace))
         
         # Build both release and debug for dual packaging
-        # proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-        # omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-
-        # print(f"OpenMP_ROOT {omp_prefix_path}")
-
-        # value = os.getenv("OpenMP_ROOT")
-        # print(value if value is not None else "OpenMP_ROOT variable not set")
-
-        # value = os.getenv("CPPFLAGS")
-        # print(value if value is not None else "CPPFLAGS variable not set")
-
-        # os.environ["OpenMP_ROOT"] = omp_prefix_path
-        #os.environ["LDFLAGS"] = f"{omp_prefix_path}/lib"
-        #os.environ["CPPFLAGS"] = f"{omp_prefix_path}/include"
-
         cmake_debug = self._configure_cmake()
         cmake_debug.build(build_type="Debug")
         cmake_debug.install(build_type="Debug")

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class FaissConan(ConanFile):
         if self.settings.os == "Macos":
             generator = "Xcode"
 
-        if self.settings.os == "Linux":
+        if os_info.is_linux:
             generator = "Ninja Multi-Config"
 
         tc = CMakeToolchain(self, generator=generator)
@@ -61,7 +61,7 @@ class FaissConan(ConanFile):
         tc.variables["BUILD_TESTING"] = "ON" if self.options.testing else "OFF"
         tc.variables["BUILD_SHARED_LIBS"] = "ON" if self.options.shared else "OFF"
 
-        if self.settings.os == "Windows":
+        if os_info.is_windows:
             # tc.variables["MKL_ROOT_DIR"] = "D:/intelmkl"
             tc.variables["BLA_STATIC"] = "ON"
             tc.variables["BLAS_LIBRARY:FILEPATH"] = PurePosixPath(self.BLAS_ROOT / "lib/x64/libopenblas.dll.a")
@@ -73,13 +73,11 @@ class FaissConan(ConanFile):
             #tc.variables["BLAS_LIBRARY"] = "D:/temp/testopenblasOpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a"
             #tc.variables["LAPACK_LIBRARY"] = "D:/temp/testopenblasOpenBLAS.0.2.14.1/lib/native/lib/x64/libopenblas.dll.a"
 
-        if self.settings.os == "Linux":
+        if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
-        if self.settings.os == "Macos":
-            proc = subprocess.run(
-                "brew --prefix libomp", shell=True, capture_output=True
-            )
+        if os_info.is_macos:
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
             prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
             tc.variables["OpenMP_ROOT"] = prefix_path
 
@@ -94,7 +92,7 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        if self.settings.os == "Macos":
+        if os_info.is_macos:
             installer = SystemPackageTool()
             installer.install("libomp")
             # Make the brew OpenMP findable with a symlink

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,32 +92,19 @@ class FaissConan(ConanFile):
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
         if os_info.is_macos:
-            proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
-            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
-            print(f"cmake version: {cmake_version}")
-
-            #cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            # cmake_version_major = int(cmake_version.split('.')[0])
-            # cmake_version_minor = int(cmake_version.split('.')[1])
-
-            # print(f"cmake_version_major: {cmake_version_major}")
-            # print(f"cmake_version_minor: {cmake_version_minor}")
-
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            os.environ["OpenMP_ROOT"] = omp_prefix_path
 
-            # if cmake_version_major == 3 and cmake_version_minor > 26:
-            #     print("Workaround...")
-            #     tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
-            #     tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-            #     tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
-            #     tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
-            #     tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-            #     tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
-            #     tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
-            # else:
-            #     tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
+            tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+            tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
+            tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
+            tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+            tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
+            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
+
+            #tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            #os.environ["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
@@ -151,8 +138,8 @@ class FaissConan(ConanFile):
 
         # print(f"OpenMP_ROOT {omp_prefix_path}")
 
-        value = os.getenv("OpenMP_ROOT")
-        print(value if value is not None else "OpenMP_ROOT variable not set")
+        # value = os.getenv("OpenMP_ROOT")
+        # print(value if value is not None else "OpenMP_ROOT variable not set")
 
         # value = os.getenv("CPPFLAGS")
         # print(value if value is not None else "CPPFLAGS variable not set")

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,9 +42,10 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        if os_info.is_macos:
-            installer = SystemPackageTool()
-            installer.install("libomp")
+        pass
+        # if os_info.is_macos:
+        #     installer = SystemPackageTool()
+        #     installer.install("libomp")
 
     def generate(self):
         print("In generate")
@@ -91,14 +92,14 @@ class FaissConan(ConanFile):
         # cmake might have issues with finding openmp
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        if os_info.is_macos:
-            proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
-            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+        # if os_info.is_macos:
+        #     proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
+        #     cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
         #     cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+            # version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
 
-            print(f"cmake version: {cmake_version}")
-            print(f"version_tuple: {version_tuple}")
+            # print(f"cmake version: {cmake_version}")
+            # print(f"version_tuple: {version_tuple}")
 
         #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
         #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
@@ -142,18 +143,18 @@ class FaissConan(ConanFile):
 # '''.format(line_to_replace))
         
         # Build both release and debug for dual packaging
-        proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-        omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+        # proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+        # omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-        print(f"OpenMP_ROOT {omp_prefix_path}")
+        # print(f"OpenMP_ROOT {omp_prefix_path}")
 
-        value = os.getenv("LDFLAGS")
-        print(value if value is not None else "LDFLAGS variable not set")
+        # value = os.getenv("LDFLAGS")
+        # print(value if value is not None else "LDFLAGS variable not set")
 
-        value = os.getenv("CPPFLAGS")
-        print(value if value is not None else "CPPFLAGS variable not set")
+        # value = os.getenv("CPPFLAGS")
+        # print(value if value is not None else "CPPFLAGS variable not set")
 
-        os.environ["OpenMP_ROOT"] = omp_prefix_path
+        # os.environ["OpenMP_ROOT"] = omp_prefix_path
         #os.environ["LDFLAGS"] = f"{omp_prefix_path}/lib"
         #os.environ["CPPFLAGS"] = f"{omp_prefix_path}/include"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -99,7 +99,7 @@ class FaissConan(ConanFile):
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-            if self.settings.arch.startswith("arm"):
+            if self.settings.compiler.version > 14:
                 print("ARM")
                 tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
                 tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"

--- a/conanfile.py
+++ b/conanfile.py
@@ -99,18 +99,20 @@ class FaissConan(ConanFile):
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-            #if self.settings.compiler.version > 14:
-                #print("ARM")
-            tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-            tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
-            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
-            tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
-            tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-            tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
-            #else:
-            #    print("x86")
-            #    tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            print(f"self.settings.arch: {self.settings.arch}")
+
+            if self.settings.arch == "armv8":
+                print("ARM")
+                tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
+                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
+                tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
+                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
+                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
+            else:
+               print("x86")
+               tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,21 +98,20 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
-            print(f"self.settings.arch: {self.settings.arch}")
-
-            if self.settings.arch == "armv8":
-                print("ARM")
-                tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
-                tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
-                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
-                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
-            else:
-               print("x86")
-               tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            # if self.settings.arch == "armv8":
+            #     print("Apple armv8")
+            #     tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
+            #     tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
+            #     tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
+            #     tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
+            #     tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+            #     tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+            #     tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
+            # else:
+            #    print("Apple x86_64")
+            #    tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"

--- a/conanfile.py
+++ b/conanfile.py
@@ -35,7 +35,19 @@ class FaissConan(ConanFile):
         self.run(f"git checkout tags/v{self.version}")
         os.chdir("..")
 
-    def _get_tc(self):
+    def layout(self):
+        # Cause the libs and bin to be output to separate subdirs
+        # based on build configuration.
+        self.cpp.package.libdirs = ["lib/$<CONFIG>"]
+        self.cpp.package.bindirs = ["bin/$<CONFIG>"]
+
+    def system_requirements(self):
+        if os_info.is_macos:
+            installer = SystemPackageTool()
+            installer.install("libomp")
+
+    def generate(self):
+        print("In generate")
         """Generate the CMake configuration using
         multi-config generators on all platforms, as follows:
 
@@ -76,33 +88,15 @@ class FaissConan(ConanFile):
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
-        if os_info.is_macos:
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            print(f"prefix_path: {prefix_path}")
-            tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
+        #if os_info.is_macos:
+            # proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            # prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            # print(f"prefix_path: {prefix_path}")
+            # tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
-        return tc
-
-    def layout(self):
-        # Cause the libs and bin to be output to separate subdirs
-        # based on build configuration.
-        self.cpp.package.libdirs = ["lib/$<CONFIG>"]
-        self.cpp.package.bindirs = ["bin/$<CONFIG>"]
-
-    def system_requirements(self):
-        if os_info.is_macos:
-            installer = SystemPackageTool()
-            installer.install("libomp")
-
-    def generate(self):
-        print("In generate")
-        tc = self._get_tc()
         tc.generate()
-        deps = CMakeDeps(self)
-        deps.generate()
 
     def _configure_cmake(self):
         cmake = CMake(self)

--- a/conanfile.py
+++ b/conanfile.py
@@ -99,18 +99,18 @@ class FaissConan(ConanFile):
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-            if self.settings.compiler.version > 14:
-                print("ARM")
-                tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
-                tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
-                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
-                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
-            else:
-                print("x86")
-                tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            #if self.settings.compiler.version > 14:
+                #print("ARM")
+            tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
+            tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
+            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
+            tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
+            tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+            tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
+            #else:
+            #    print("x86")
+            #    tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"

--- a/conanfile.py
+++ b/conanfile.py
@@ -98,7 +98,7 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
             tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp "
+            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path, PurePosixPath
 import subprocess
 
-required_conan_version = ">=1.51.0"
+required_conan_version = ">=1.66.0"
 
 
 class FaissConan(ConanFile):

--- a/conanfile.py
+++ b/conanfile.py
@@ -94,11 +94,12 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
             cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+            print(f"cmake version: {cmake_version}")
+
             #cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
             cmake_version_major = int(cmake_version.split('.')[0])
             cmake_version_minor = int(cmake_version.split('.')[1])
 
-            print(f"cmake version: {cmake_version}")
             print(f"cmake_version_major: {cmake_version_major}")
             print(f"cmake_version_minor: {cmake_version_minor}")
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -76,11 +76,6 @@ class FaissConan(ConanFile):
         if os_info.is_linux:
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
-        if os_info.is_macos:
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            tc.variables["OpenMP_ROOT"] = prefix_path
-
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
         return tc
@@ -95,9 +90,6 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             installer = SystemPackageTool()
             installer.install("libomp")
-            # Make the brew OpenMP findable with a symlink
-            proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
-            subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
 
     def generate(self):
         print("In generate")

--- a/conanfile.py
+++ b/conanfile.py
@@ -96,9 +96,11 @@ class FaissConan(ConanFile):
             tc.variables["CMAKE_CONFIGURATION_TYPES"] = "Debug;Release;RelWithDebInfo"
 
         if os_info.is_macos:
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)      
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
             tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
             tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
+            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -45,12 +45,12 @@ class FaissConan(ConanFile):
 
     def system_requirements(self):
         pass
-        # if os_info.is_macos:
-        #     installer = SystemPackageTool()
-        #     installer.install("libomp")
-        #     # Make the brew OpenMP findable with a symlink
-        #     proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
-        #     subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
+        if os_info.is_macos:
+            installer = SystemPackageTool()
+            installer.install("libomp")
+            # Make the brew OpenMP findable with a symlink
+            proc = subprocess.run("brew --prefix libomp",  shell=True, capture_output=True)
+            subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
 
     def generate(self):
         print("In generate")
@@ -98,9 +98,20 @@ class FaissConan(ConanFile):
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-            tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
-            tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
+
+            if self.settings.arch.startswith("arm"):
+                print("ARM")
+                tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
+                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
+                tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
+                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
+                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
+                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
+            else:
+                print("x86")
+                tc.variables["OpenMP_ROOT"] = omp_prefix_path
+
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -53,20 +53,8 @@ class FaissConan(ConanFile):
             subprocess.run(f"ln {proc.stdout.decode('UTF-8').strip()}/lib/libomp.dylib /usr/local/lib/libomp.dylib", shell=True)
 
     def generate(self):
-        print("In generate")
-        """Generate the CMake configuration using
-        multi-config generators on all platforms, as follows:
-
-        Windows - defaults to Visual Studio
-        Macos - XCode
-        Linux - Ninja Multi-Config
-
-        CMake needs to be at least 3.17 for Ninja Multi-Config
-
-        Returns:
-            CMakeToolchain: a configured toolchain object
-        """
         generator = None
+
         if self.settings.os == "Macos":
             generator = "Xcode"
 
@@ -100,20 +88,6 @@ class FaissConan(ConanFile):
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
             tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
-            # if self.settings.arch == "armv8":
-            #     print("Apple armv8")
-            #     tc.variables["OpenMP_CXX_FLAGS"] = "-Xclang -fopenmp"
-            #     tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp"
-            #     tc.variables["OpenMP_CXX_LIB_NAMES"] = "libomp"
-            #     tc.variables["OpenMP_C_LIB_NAMES"] = "libomp"
-            #     tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-            #     tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include"
-            #     tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib"
-            # else:
-            #    print("Apple x86_64")
-            #    tc.variables["OpenMP_ROOT"] = omp_prefix_path
-
-
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
         tc.generate()
@@ -124,22 +98,7 @@ class FaissConan(ConanFile):
         cmake.verbose = True
         return cmake
 
-    def build(self):
-        # list(TRANSFORM CMAKE_MODULE_PATH PREPEND ${{CMAKE_CURRENT_SOURCE_DIR}}/../cmake)
-#         if self.settings.os == "Windows":         
-#             line_to_replace = 'set(MKL_LIBRARIES)'
-#             tools.replace_in_file("faiss/cmake/FindMKL.cmake", line_to_replace,
-#                               '''{}
-# set(ENV{{MKLROOT}} "D:/intelmkl/intelmkl.devel.win-x64.2023.2.0.49496" ) 
-# message(STATUS "**************In faiss ${{CMAKE_CURRENT_LIST_FILE}} *************")
-# '''.format(line_to_replace))
-            
-#             line_to_replace = 'if(NOT ${_LIBRARIES})'
-#             tools.replace_in_file("faiss/cmake/FindMKL.cmake", line_to_replace,
-#                               '''message(STATUS "**************MKL In libs search ${{IT}} == ${{BLAS_mkl_MKLROOT}} == ${{BLAS_mkl_LIB_PATH_SUFFIXES}}*************")
-#                               {}
-# '''.format(line_to_replace))
-        
+    def build(self):       
         # Build both release and debug for dual packaging
         cmake_debug = self._configure_cmake()
         cmake_debug.build(build_type="Debug")

--- a/conanfile.py
+++ b/conanfile.py
@@ -91,29 +91,29 @@ class FaissConan(ConanFile):
         # cmake might have issues with finding openmp
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        if os_info.is_macos:
-            proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
-            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
-            cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+        # if os_info.is_macos:
+        #     proc = subprocess.run("cmake --version", shell=True, capture_output=True)       
+        #     cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+        #     cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
+        #     version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
 
-            print(f"cmake version: {cmake_version}")
-            print(f"version_tuple: {version_tuple}")
+        #     print(f"cmake version: {cmake_version}")
+        #     print(f"version_tuple: {version_tuple}")
 
-            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+        #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+        #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-            if version_tuple[0] == 3 and version_tuple[1] > 26:
-                print("Workaround...")
-                tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
-                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-                tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
-                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
-                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
-                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
-            else:
-                tc.variables["OpenMP_ROOT"] = omp_prefix_path
+        #     if version_tuple[0] == 3 and version_tuple[1] > 26:
+        #         print("Workaround...")
+        #         tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
+        #         tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+        #         tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
+        #         tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
+        #         tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+        #         tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
+        #         tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
+        #     else:
+        #         tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
@@ -142,6 +142,13 @@ class FaissConan(ConanFile):
 # '''.format(line_to_replace))
         
         # Build both release and debug for dual packaging
+        proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+        omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+
+        print(f"OpenMP_ROOT {omp_prefix_path}")
+
+        os.environ["OpenMP_ROOT"] = omp_prefix_path
+
         cmake_debug = self._configure_cmake()
         cmake_debug.build(build_type="Debug")
         cmake_debug.install(build_type="Debug")

--- a/conanfile.py
+++ b/conanfile.py
@@ -97,26 +97,27 @@ class FaissConan(ConanFile):
             print(f"cmake version: {cmake_version}")
 
             #cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            cmake_version_major = int(cmake_version.split('.')[0])
-            cmake_version_minor = int(cmake_version.split('.')[1])
+            # cmake_version_major = int(cmake_version.split('.')[0])
+            # cmake_version_minor = int(cmake_version.split('.')[1])
 
-            print(f"cmake_version_major: {cmake_version_major}")
-            print(f"cmake_version_minor: {cmake_version_minor}")
+            # print(f"cmake_version_major: {cmake_version_major}")
+            # print(f"cmake_version_minor: {cmake_version_minor}")
 
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            os.environ["OpenMP_ROOT"] = omp_prefix_path
 
-            if cmake_version_major == 3 and cmake_version_minor > 26:
-                print("Workaround...")
-                tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
-                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-                tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
-                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
-                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
-                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
-            else:
-                tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            # if cmake_version_major == 3 and cmake_version_minor > 26:
+            #     print("Workaround...")
+            #     tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
+            #     tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+            #     tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
+            #     tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
+            #     tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+            #     tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
+            #     tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
+            # else:
+            #     tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 
@@ -150,8 +151,8 @@ class FaissConan(ConanFile):
 
         # print(f"OpenMP_ROOT {omp_prefix_path}")
 
-        # value = os.getenv("LDFLAGS")
-        # print(value if value is not None else "LDFLAGS variable not set")
+        value = os.getenv("OpenMP_ROOT")
+        print(value if value is not None else "OpenMP_ROOT variable not set")
 
         # value = os.getenv("CPPFLAGS")
         # print(value if value is not None else "CPPFLAGS variable not set")

--- a/conanfile.py
+++ b/conanfile.py
@@ -42,10 +42,9 @@ class FaissConan(ConanFile):
         self.cpp.package.bindirs = ["bin/$<CONFIG>"]
 
     def system_requirements(self):
-        pass
-        # if os_info.is_macos:
-        #     installer = SystemPackageTool()
-        #     installer.install("libomp")
+        if os_info.is_macos:
+            installer = SystemPackageTool()
+            installer.install("libomp")
 
     def generate(self):
         print("In generate")
@@ -92,29 +91,30 @@ class FaissConan(ConanFile):
         # cmake might have issues with finding openmp
         # https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860/12
         # https://gitlab.kitware.com/cmake/cmake/-/issues/24097
-        # if os_info.is_macos:
-        #     proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
-        #     cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
-        #     cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
-            # version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
+        if os_info.is_macos:
+            proc = subprocess.run("cmake --version | grep -oP '\d+\.\d+\.\d+'", shell=True, capture_output=True)       
+            cmake_version = f"{proc.stdout.decode('UTF-8').strip()}"
+            #cmake_version = cmake_version.split()[-1]  # Get e.g. "3.31.5"
+            version_tuple = tuple(map(int, cmake_version.split('.')))  # (3, 31, 5)
 
-            # print(f"cmake version: {cmake_version}")
-            # print(f"version_tuple: {version_tuple}")
+            print(f"cmake version: {cmake_version}")
+            print(f"version_tuple[0]: {version_tuple[0]}")
+            print(f"version_tuple[1]: {version_tuple[1]}")
 
-        #     proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-        #     omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
 
-        #     if version_tuple[0] == 3 and version_tuple[1] > 26:
-        #         print("Workaround...")
-        #         tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
-        #         tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-        #         tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
-        #         tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
-        #         tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
-        #         tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
-        #         tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
-        #     else:
-        #         tc.variables["OpenMP_ROOT"] = omp_prefix_path
+            if version_tuple[0] == 3 and version_tuple[1] > 26:
+                print("Workaround...")
+                tc.variables["OpenMP_CXX_FLAG"] = "-Xclang -fopenmp" 
+                tc.variables["OpenMP_CXX_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+                tc.variables["OpenMP_CXX_LIB_NAMES"] = "-libomp" 
+                tc.variables["OpenMP_C_FLAG"] = "-Xclang -fopenmp" 
+                tc.variables["OpenMP_C_INCLUDE_DIR"] = f"{omp_prefix_path}/include" 
+                tc.variables["OpenMP_C_LIB_NAMES"] = "libomp" 
+                tc.variables["OpenMP_libomp_LIBRARY"] = f"{omp_prefix_path}/lib/libomp.dylib" 
+            else:
+                tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -90,9 +90,10 @@ class FaissConan(ConanFile):
 
         if os_info.is_macos:
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
-            prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
-            print(f"prefix_path: {prefix_path}")
-            tc.variables["CMAKE_PREFIX_PATH"] = prefix_path
+            omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
+            print(f"omp_prefix_path: {omp_prefix_path}")
+            tc.variables["CMAKE_CXX_FLAGS"] = f"-I{omp_prefix_path}/include -Xclang -fopenmp"
+            tc.variables["CMAKE_EXE_LINKER_FLAGS"] = f"-L{omp_prefix_path}/lib -lomp"
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -92,8 +92,7 @@ class FaissConan(ConanFile):
             proc = subprocess.run("brew --prefix libomp", shell=True, capture_output=True)       
             omp_prefix_path = f"{proc.stdout.decode('UTF-8').strip()}"
             print(f"omp_prefix_path: {omp_prefix_path}")
-            tc.variables["CMAKE_CXX_FLAGS"] = f"-I{omp_prefix_path}/include -Xclang -fopenmp"
-            tc.variables["CMAKE_EXE_LINKER_FLAGS"] = f"-L{omp_prefix_path}/lib -lomp"
+            tc.variables["OpenMP_ROOT"] = omp_prefix_path
 
         tc.variables["CMAKE_CXX_STANDARD"] = "17"
 


### PR DESCRIPTION
- Remove `ubuntu-20.04`
- Remove `macos-12`
- Add `windows-2022`
- Add `macos-14`  (XCode 15.4, ARM)
- Add `macos-15` (XCode 16.2, ARM)

See https://github.com/actions/runner-images/issues/10721
> The macOS 12 Actions runner image will begin deprecation on 10/7/24 and will be fully unsupported by 12/3/24 for GitHub and by 01/13/25 for ADO

See https://github.com/actions/runner-images/issues/11101
> The Ubuntu 20.04 Actions runner image will begin deprecation on 2025-02-01 and will be fully unsupported by 2025-04-01 

Also: 
- Update conan to [1.66 which adds new apple-clang 16](https://github.com/conan-io/conan/releases/tag/1.66.0) (Otherwise adding `macos-15` (XCode 16.2) won't compile)
- Do not install and use CMake with Python. This majorly interferes with finding and `OpenMP` and Apple's ARM platforms